### PR TITLE
Fix: Allow auto EOL for toml in .gitattibutes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,5 @@
 *.png binary
 *.ogg binary
 *.nbt binary
+
+*.toml text=auto

--- a/config/flywheel-client.toml
+++ b/config/flywheel-client.toml
@@ -3,7 +3,7 @@ backend = "DEFAULT"
 #Enable or disable instance update limiting with distance.
 limitUpdates = true
 #The number of worker threads to use. Set to -1 to let Flywheel decide. Set to 0 to disable parallelism. Requires a game restart to take effect.
-#Range: -1 ~ 10
+#Range: -1 ~ 16
 workerThreads = -1
 
 #Config options for Flywheel's built-in backends.


### PR DESCRIPTION
Resolves an issue where Minecraft would automatically rewrite *.toml config files with CRLF line endings upon launch.

The strict `eol=lf` rule caused these files to appear as `modified` in git's changelog despite no actual content changes. Switching to `*.toml text=auto`, we allow git to handle the line changes itself, while enforcing LF on all other text files. May need to add the same allowance for `json` files in the future.